### PR TITLE
Introduce buildTypeDictsScalar to eliminate many ScalarType traversals

### DIFF
--- a/accelerate-tensorflow-lite/src/Data/Array/Accelerate/TensorFlow/Lite/Compile.hs
+++ b/accelerate-tensorflow-lite/src/Data/Array/Accelerate/TensorFlow/Lite/Compile.hs
@@ -16,14 +16,13 @@ module Data.Array.Accelerate.TensorFlow.Lite.Compile (
 
 ) where
 
-import Data.Array.Accelerate.Type
 import Data.Array.Accelerate.Representation.Array
 import Data.Array.Accelerate.Representation.Type
 import qualified Data.Array.Accelerate.Debug.Internal               as Debug
 
 import Data.Array.Accelerate.TensorFlow.CodeGen.AST
-import Data.Array.Accelerate.TensorFlow.CodeGen.Base
 import Data.Array.Accelerate.TensorFlow.CodeGen.Tensor
+import Data.Array.Accelerate.TensorFlow.TypeDicts
 
 import Data.Array.Accelerate.TensorFlow.Lite.Representation.Args
 
@@ -168,35 +167,7 @@ graph_of_model (Tbody arrR model) =
       array :: TF.MonadBuild m => TypeR t -> TensorArrayData t -> m ()
       array TupRunit         ()     = return ()
       array (TupRpair aR bR) (a, b) = array aR a >> array bR b
-      array (TupRsingle aR)  a      = scalar aR a
-
-      scalar :: TF.MonadBuild m => ScalarType t -> TensorArrayData t -> m ()
-      scalar (SingleScalarType t) = single t
-      scalar (VectorScalarType _) = unsupported "SIMD-vector types"
-
-      single :: TF.MonadBuild m => SingleType t -> TensorArrayData t -> m ()
-      single (NumSingleType t) = num t
-
-      num :: TF.MonadBuild m => NumType t -> TensorArrayData t -> m ()
-      num (IntegralNumType t) = integral t
-      num (FloatingNumType t) = floating t
-
-      integral :: TF.MonadBuild m => IntegralType t -> TensorArrayData t -> m ()
-      integral TypeInt8   = render
-      integral TypeInt16  = render
-      integral TypeInt32  = render
-      integral TypeInt64  = render
-      integral TypeWord8  = render
-      integral TypeWord16 = render
-      integral TypeWord32 = render
-      integral TypeWord64 = render
-      integral TypeInt    = render
-      integral TypeWord   = render
-
-      floating :: TF.MonadBuild m => FloatingType t -> TensorArrayData t -> m ()
-      floating TypeFloat  = render
-      floating TypeDouble = render
-      floating TypeHalf   = unsupported "half-precision floating point"
+      array (TupRsingle aR)  a      = buildTypeDictsScalar aR render a
 
       render :: TF.MonadBuild m => TF.Tensor TF.Build a -> m ()
       render t = TF.render t >> return ()

--- a/accelerate-tensorflow-lite/src/Data/Array/Accelerate/TensorFlow/Lite/Representation/Args.hs
+++ b/accelerate-tensorflow-lite/src/Data/Array/Accelerate/TensorFlow/Lite/Representation/Args.hs
@@ -20,6 +20,7 @@ module Data.Array.Accelerate.TensorFlow.Lite.Representation.Args
   where
 
 import Data.Array.Accelerate.TensorFlow.CodeGen.Base
+import Data.Array.Accelerate.TensorFlow.TypeDicts
 import Data.Array.Accelerate.TensorFlow.Lite.Representation.Shapes
 
 import Data.Array.Accelerate.Array.Data
@@ -77,35 +78,7 @@ buildArgs args =
                 buildArrayData :: TypeR e -> ArrayData e -> Builder
                 buildArrayData TupRunit         ()     = mempty
                 buildArrayData (TupRpair aR bR) (a, b) = buildArrayData aR a <> buildArrayData bR b
-                buildArrayData (TupRsingle aR)  a      = B.word8 (tagOfType aR) <> scalar aR a
-
-                scalar :: ScalarType a -> ArrayData a -> Builder
-                scalar (SingleScalarType t) = single t
-                scalar (VectorScalarType _) = unsupported "SIMD-vector types"
-
-                single :: SingleType a -> ArrayData a -> Builder
-                single (NumSingleType t) = num t
-
-                num :: NumType a -> ArrayData a -> Builder
-                num (IntegralNumType t) = integral t
-                num (FloatingNumType t) = floating t
-
-                integral :: IntegralType a -> ArrayData a -> Builder
-                integral TypeInt8   = wrap
-                integral TypeInt16  = wrap
-                integral TypeInt32  = wrap
-                integral TypeInt64  = wrap
-                integral TypeWord8  = wrap
-                integral TypeWord16 = wrap
-                integral TypeWord32 = wrap
-                integral TypeWord64 = wrap
-                integral TypeInt    = wrap
-                integral TypeWord   = wrap
-
-                floating :: FloatingType a -> ArrayData a -> Builder
-                floating TypeHalf   = wrap
-                floating TypeFloat  = wrap
-                floating TypeDouble = wrap
+                buildArrayData (TupRsingle aR)  a      = B.word8 (tagOfType aR) <> buildTypeDictsScalar aR wrap a
 
                 wrap :: forall a. Storable a => UniqueArray a -> Builder
                 wrap (unsafeGetValue . uniqueArrayData -> fp)

--- a/accelerate-tensorflow/accelerate-tensorflow.cabal
+++ b/accelerate-tensorflow/accelerate-tensorflow.cabal
@@ -35,6 +35,7 @@ library
       Data.Array.Accelerate.TensorFlow.CodeGen.Exp
       Data.Array.Accelerate.TensorFlow.CodeGen.Foreign
       Data.Array.Accelerate.TensorFlow.CodeGen.Tensor
+      Data.Array.Accelerate.TensorFlow.TypeDicts
   other-modules:
       Paths_accelerate_tensorflow
   hs-source-dirs:

--- a/accelerate-tensorflow/src/Data/Array/Accelerate/TensorFlow/CodeGen/Tensor.hs
+++ b/accelerate-tensorflow/src/Data/Array/Accelerate/TensorFlow/CodeGen/Tensor.hs
@@ -66,19 +66,22 @@ type family TArrayDataR ba a where
   TArrayDataR ba (a, b) = (TArrayDataR ba a, TArrayDataR ba b)
   TArrayDataR ba a      = ba (ScalarTensorDataR a)
 
+type HostEquivalentInt  = $( case finiteBitSize (undefined :: Int) of
+                               32 -> [t| Int32 |]
+                               64 -> [t| Int64 |]
+                               _  -> error "expected 32- or 64-bit integer type" )
+type HostEquivalentWord = $( case finiteBitSize (undefined :: Word) of
+                               32 -> [t| Word32 |]
+                               64 -> [t| Word64 |]
+                               _  -> error "expected 32- or 64-bit unsigned integer type" )
+
 type family ScalarTensorDataR t where
-  ScalarTensorDataR Int       = $( case finiteBitSize (undefined :: Int) of
-                                     32 -> [t| Int32 |]
-                                     64 -> [t| Int64 |]
-                                     _  -> error "expected 32- or 64-bit integer type" )
+  ScalarTensorDataR Int       = HostEquivalentInt
   ScalarTensorDataR Int8      = Int8
   ScalarTensorDataR Int16     = Int16
   ScalarTensorDataR Int32     = Int32
   ScalarTensorDataR Int64     = Int64
-  ScalarTensorDataR Word      = $( case finiteBitSize (undefined :: Word) of
-                                     32 -> [t| Word32 |]
-                                     64 -> [t| Word64 |]
-                                     _  -> error "expected 32- or 64-bit unsigned integer type" )
+  ScalarTensorDataR Word      = HostEquivalentWord
   ScalarTensorDataR Word8     = Word8
   ScalarTensorDataR Word16    = Word16
   ScalarTensorDataR Word32    = Word32

--- a/accelerate-tensorflow/src/Data/Array/Accelerate/TensorFlow/TypeDicts.hs
+++ b/accelerate-tensorflow/src/Data/Array/Accelerate/TensorFlow/TypeDicts.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
+module Data.Array.Accelerate.TensorFlow.TypeDicts (
+  buildTypeDictsScalar,
+  Convertable(..),
+) where
+
+import Data.Array.Accelerate.TensorFlow.CodeGen.Base
+import Data.Array.Accelerate.TensorFlow.CodeGen.Tensor
+
+import Data.Array.Accelerate.Array.Data (GArrayDataR)
+import Data.Array.Accelerate.Array.Unique (UniqueArray)
+import Data.Array.Accelerate.Type
+
+import Foreign.Storable
+import qualified TensorFlow.Core                                    as TF
+import Data.ByteString.Char8
+
+
+class Convertable a b where
+  convertConvertable :: a -> b
+
+instance Convertable Int HostEquivalentInt where
+  convertConvertable = fromIntegral
+
+instance Convertable Word HostEquivalentWord where
+  convertConvertable = fromIntegral
+
+instance {-# OVERLAPPABLE #-} Convertable a a where
+  convertConvertable = id
+
+type TypeDictsFor t s =
+  (Storable t
+  ,IsScalar t
+  ,s ~ ScalarTensorDataR t
+  ,TF.TensorType s
+  ,TArrayDataR (TF.Tensor TF.Build) t ~ TF.Tensor TF.Build s
+  ,GArrayDataR UniqueArray t ~ UniqueArray t
+  ,s TF./= ByteString
+  ,s TF./= Bool
+  ,Convertable t s)
+
+buildTypeDictsScalar :: forall t r. ScalarType t -> (forall s. TypeDictsFor t s => r) -> r
+buildTypeDictsScalar (SingleScalarType t) f = buildTypeDictsSingle t f
+buildTypeDictsScalar (VectorScalarType _) _ = unsupported "SIMD-vector types"
+
+buildTypeDictsSingle :: forall t r. SingleType t -> (forall s. TypeDictsFor t s => r) -> r
+buildTypeDictsSingle (NumSingleType t) f = buildTypeDictsNum t f
+
+buildTypeDictsNum :: forall t r. NumType t -> (forall s. TypeDictsFor t s => r) -> r
+buildTypeDictsNum (IntegralNumType t) f = buildTypeDictsIntegral t f
+buildTypeDictsNum (FloatingNumType t) f = buildTypeDictsFloating t f
+
+buildTypeDictsIntegral :: forall t r. IntegralType t -> (forall s. TypeDictsFor t s => r) -> r
+buildTypeDictsIntegral TypeInt8   f = f
+buildTypeDictsIntegral TypeInt16  f = f
+buildTypeDictsIntegral TypeInt32  f = f
+buildTypeDictsIntegral TypeInt64  f = f
+buildTypeDictsIntegral TypeWord8  f = f
+buildTypeDictsIntegral TypeWord16 f = f
+buildTypeDictsIntegral TypeWord32 f = f
+buildTypeDictsIntegral TypeWord64 f = f
+buildTypeDictsIntegral TypeInt    f = f
+buildTypeDictsIntegral TypeWord   f = f
+
+buildTypeDictsFloating :: forall t r. FloatingType t -> (forall s. TypeDictsFor t s => r) -> r
+buildTypeDictsFloating TypeFloat  f = f
+buildTypeDictsFloating TypeDouble f = f
+buildTypeDictsFloating TypeHalf   _ = unsupported "half-precision floating point"


### PR DESCRIPTION
@dpvanbalen

This eliminates not all but a lot of the repeated ScalarType traversals throughout the codebase. TODO are eliminating the traversals in:
- `accelerate-tensorflow/src/Data/Array/Accelerate/TensorFlow/CodeGen/Tensor.hs`: annoying because importing TypeDicts.hs there would yield an import cycle. Moving the TypeDicts stuff to Tensor.hs would work, but not sure whether that's a good idea.
- `accelerate-tensorflow/src/Data/Array/Accelerate/TensorFlow/CodeGen/Arithmetic.hs`: I was lazy, don't see fundamental difficulties (might need to add the OneOf constraint to the TypeDictsFor list)

What do you think?